### PR TITLE
Add inject/join for FORMAT_TEXT_MAP

### DIFF
--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -9,6 +9,7 @@ class ClientSpan implements \LightStepBase\Span {
     protected $_tracer = null;
 
     protected $_guid = "";
+    protected $_traceGUID = "";
     protected $_operation = "";
     protected $_tags = array();
     protected $_baggage = array();
@@ -20,6 +21,7 @@ class ClientSpan implements \LightStepBase\Span {
 
     public function __construct($tracer) {
         $this->_tracer = $tracer;
+        $this->_traceGUID = $tracer->_generateUUIDString();
         $this->_guid = $tracer->_generateUUIDString();
     }
 
@@ -37,6 +39,15 @@ class ClientSpan implements \LightStepBase\Span {
 
     public function guid() {
         return $this->_guid;
+    }
+
+    public function traceGUID() {
+        return $this->_traceGUID;
+    }
+
+    public function setTraceGUID($guid) {
+        $this->_traceGUID = $guid;
+        return $this;
     }
 
     public function setStartMicros($start) {
@@ -82,6 +93,10 @@ class ClientSpan implements \LightStepBase\Span {
         return $this->_baggage[$key];
     }
 
+    public function getBaggage() {
+        return $this->_baggage;
+    }
+
     public function setParent($span) {
         // Inherit any join IDs from the parent that have not been explicitly
         // set on the child
@@ -93,6 +108,15 @@ class ClientSpan implements \LightStepBase\Span {
 
         $this->setTag("parent_span_guid", $span->guid());
         return $this;
+    }
+
+    public function setParentGUID($guid) {
+        $this->setTag("parent_span_guid", $guid);
+        return $this;
+    }
+
+    public function getParentGUID() {
+        return $this->_tags['parent_span_guid'];
     }
 
     public function logEvent($event, $payload = NULL) {
@@ -167,6 +191,7 @@ class ClientSpan implements \LightStepBase\Span {
         $rec = new \CroutonThrift\SpanRecord(array(
             "runtime_guid" => strval($this->_tracer->guid()),
             "span_guid" => strval($this->_guid),
+            "trace_guid" => strval($this->_traceGUID),
             "span_name" => strval($this->_operation),
             "oldest_micros" => intval($this->_startMicros),
             "youngest_micros" => intval($this->_endMicros),

--- a/lib/api.php
+++ b/lib/api.php
@@ -2,6 +2,11 @@
 
 namespace LightStepBase;
 
+// TODO: these constants should be replaced with OpenTracing constants as soon
+// as a OpenTracing PHP library exists.
+define("LIGHTSTEP_FORMAT_TEXT_MAP", "LIGHTSTEP_FORMAT_TEXT_MAP");
+define("LIGHTSTEP_FORMAT_BINARY", "LIGHTSTEP_FORMAT_BINARY");
+
 /**
  *@internal
  *
@@ -39,11 +44,30 @@ interface Tracer {
      */
     public function startSpan($operationName, $fields);
 
-    // TODO: Not yet supported
-    //public function inject($span, $format, $carrier);
+    /**
+     * Copies the span data into the given carrier object.
+     *
+     * See http://opentracing.io/spec/#inject-and-join.
+     *
+     * @param  Span $span the span object that will populate $carrier
+     * @param  string $format the OpenTracing constant for the format of $carrier
+     * @param  mixed $carrier the carrier object; the type depends on the $format
+     */
+    public function inject($span, $format, &$carrier);
 
-    // TODO: Not yet supported
-    //public function join($span, $format, $carrier);
+    /**
+     * Creates a new span data from the given carrier object.
+     *
+     * See http://opentracing.io/spec/#inject-and-join.
+     *
+     * @param  string $operationName operation name to use for the newly created
+     *                               span
+     * @param  string $format the OpenTracing constant for the format of the
+     *                        carrier object
+     * @param  mixed $carrier carrier object; the type depends on $format
+     * @return Span the newly created Span
+     */
+    public function join($operationName, $format, $carrier);
 
     // ---------------------------------------------------------------------- //
     // LightStep Extentsions
@@ -154,16 +178,11 @@ interface Span {
     // ---------------------------------------------------------------------- //
 
     /**
-     * Sets a string uniquely identifying the user on behalf the
-     * span operation is being run. This may be an identifier such
-     * as unique username or any other application-specific identifier
-     * (as long as it is used consistently for this user).
+     * Returns the unique identifier for the span instance.
      *
-     *
-     *
-     * @param string $id a unique identifier of the
+     * @return string
      */
-    public function setEndUserId($id);
+    public function guid();
 
     /**
      * Explicitly associates this span as a child operation of the
@@ -173,14 +192,6 @@ interface Span {
      * @param Span $span the parent span of this span
      */
     public function setParent($span);
-
-    /**
-     * Sets a trace join ID key-value pair.
-     *
-     * @param string $key the trace key
-     * @param string $value the value to associate with the given key.
-     */
-    public function addTraceJoinId($key, $value);
 
     /**
      * Creates a printf-style log statement that will be associated with
@@ -218,10 +229,28 @@ interface Span {
      */
     public function fatalf($fmt);
 
+    // ---------------------------------------------------------------------- //
+    // Deprecated
+    // ---------------------------------------------------------------------- //
+
     /**
-     * Returns the unique identifier for the span instance.
+     * Sets a string uniquely identifying the user on behalf the
+     * span operation is being run. This may be an identifier such
+     * as unique username or any other application-specific identifier
+     * (as long as it is used consistently for this user).
      *
-     * @return string
+     *
+     *
+     * @param string $id a unique identifier of the current user
      */
-    public function guid();
+    public function setEndUserId($id);
+
+    /**
+     * Sets a trace join ID key-value pair.
+     *
+     * @param string $key the trace key
+     * @param string $value the value to associate with the given key.
+     */
+    public function addTraceJoinId($key, $value);
+
 }

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -3,19 +3,19 @@
 class SpanTest extends PHPUnit_Framework_TestCase {
 
     public function testSpanSetOperation() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
-        $span = $runtime->startSpan("server/query");
+        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("server/query");
         $span->finish();
 
         $this->assertEquals(peek($span, "_operation"), "server/query");
     }
 
     public function testSpanStartEndMicros() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
+        $tracer = LightStep::newTracer("test_group", "1234567890");
 
         $sum = 0;
         for ($i = 0; $i < 50; $i++) {
-            $span = $runtime->startSpan("start_end");
+            $span = $tracer->startSpan("start_end");
             usleep(500);
             $span->finish();
 
@@ -35,8 +35,8 @@ class SpanTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testSpanJoinIds() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
-        $span = $runtime->startSpan("join_id_span");
+        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("join_id_span");
 
         $span->addTraceJoinId("number", "one");
         $this->assertEquals(count(peek($span, "_joinIds")), 1);
@@ -46,8 +46,8 @@ class SpanTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testSpanLogging() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
-        $span = $runtime->startSpan("log_span");
+        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("log_span");
         $span->infof("Test %d %f %s", 1, 2.0, "three");
         $span->warnf("Test %d %f %s", 1, 2.0, "three");
         $span->errorf("Test %d %f %s", 1, 2.0, "three");
@@ -55,8 +55,8 @@ class SpanTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testSpanAttributes() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
-        $span = $runtime->startSpan("attributes_span");
+        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("attributes_span");
         $span->setTag("test_attribute_1", "value 1");
         $span->setTag("test_attribute_2", "value 2");
 
@@ -70,18 +70,36 @@ class SpanTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testSpanThriftRecord() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
-        $span = $runtime->startSpan("hello/world");
+        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("hello/world");
         $span->setEnduserId("dinosaur_sr");
         $span->finish();
 
         // Transform the object into a associative array
         $arr = json_decode(json_encode($span->toThrift()), TRUE);
         $this->assertTrue(is_string($arr["span_guid"]));
+        $this->assertTrue(is_string($arr["trace_guid"]));
         $this->assertTrue(is_string($arr["runtime_guid"]));
         $this->assertTrue(is_string($arr["span_name"]));
         $this->assertEquals(1, count($arr["join_ids"]));
         $this->assertTrue(is_string($arr["join_ids"][0]["TraceKey"]));
         $this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
+    }
+
+    public function testInjectJoin() {
+        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("hello/world");
+
+        $carrier = array();
+        $tracer->inject($span, LIGHTSTEP_FORMAT_TEXT_MAP, $carrier);
+        $this->assertEquals($carrier['ot-tracer-spanid'], $span->guid());
+        $this->assertEquals($carrier['ot-tracer-traceid'], $span->traceGUID());
+        $this->assertEquals($carrier['ot-tracer-sampled'], 'true');
+        $span->finish();
+
+        $child = $tracer->join('child', LIGHTSTEP_FORMAT_TEXT_MAP, $carrier);
+        $this->assertEquals($child->traceGUID(), $span->traceGUID());
+        $this->assertEquals($child->getParentGUID(), $span->guid());
+        $child->finish();
     }
 }

--- a/thrift/CroutonThrift/Types.php
+++ b/thrift/CroutonThrift/Types.php
@@ -847,6 +847,10 @@ class SpanRecord {
   /**
    * @var string
    */
+  public $trace_guid = null;
+  /**
+   * @var string
+   */
   public $runtime_guid = null;
   /**
    * @var string
@@ -882,6 +886,10 @@ class SpanRecord {
       self::$_TSPEC = array(
         1 => array(
           'var' => 'span_guid',
+          'type' => TType::STRING,
+          ),
+        11 => array(
+          'var' => 'trace_guid',
           'type' => TType::STRING,
           ),
         2 => array(
@@ -937,6 +945,9 @@ class SpanRecord {
       if (isset($vals['span_guid'])) {
         $this->span_guid = $vals['span_guid'];
       }
+      if (isset($vals['trace_guid'])) {
+        $this->trace_guid = $vals['trace_guid'];
+      }
       if (isset($vals['runtime_guid'])) {
         $this->runtime_guid = $vals['runtime_guid'];
       }
@@ -986,6 +997,13 @@ class SpanRecord {
         case 1:
           if ($ftype == TType::STRING) {
             $xfer += $input->readString($this->span_guid);
+          } else {
+            $xfer += $input->skip($ftype);
+          }
+          break;
+        case 11:
+          if ($ftype == TType::STRING) {
+            $xfer += $input->readString($this->trace_guid);
           } else {
             $xfer += $input->skip($ftype);
           }
@@ -1171,6 +1189,11 @@ class SpanRecord {
         }
         $output->writeListEnd();
       }
+      $xfer += $output->writeFieldEnd();
+    }
+    if ($this->trace_guid !== null) {
+      $xfer += $output->writeFieldBegin('trace_guid', TType::STRING, 11);
+      $xfer += $output->writeString($this->trace_guid);
       $xfer += $output->writeFieldEnd();
     }
     $xfer += $output->writeFieldStop();


### PR DESCRIPTION
## Summary
- Add `inject` / `join` support for `LIGHTSTEP_FORMAT_TEXT_MAP` (i.e. `array` carriers)
- Add basic unit test for the prior bullet
- Normalize on a 64-bit, hex-string encoded GUID (same as other LightStep libs)
- Updates to LightStep's latest internal span reporting protocol (i.e. `trace_guid`)
