### PR TITLE
Fix defect where trace GUID was not inherited by child span

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+general:
+    branches:
+        only:
+            - master
 machine:
     php:
         version:

--- a/example.php
+++ b/example.php
@@ -1,18 +1,3 @@
-# LightStep Instrumentation Library
-
-[![Circle CI](https://circleci.com/gh/lightstep/lightstep-tracer-php.svg?style=shield)](https://circleci.com/gh/lightstep/lightstep-tracer-php)
-
-## Install with Composer
-
-```bash
-composer require lightstep/tracer
-```
-
-The `lightstep/tracer` package is [available here on packagist.org](https://packagist.org/packages/lightstep/tracer).
-
-## Instrumentation Example
-
-```php
 <?php
 
 require __DIR__ . '/vendor/autoload.php';
@@ -31,10 +16,3 @@ for ($i = 0; $i < 10; $i++) {
     usleep(1e5);
 }
 $span->finish();
-```
-
-See `lib/api.php` for detailed API documentation.
-
-## License
-
-[The MIT License](LICENSE).

--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -106,6 +106,7 @@ class ClientSpan implements \LightStepBase\Span {
             }
         }
 
+        $this->_traceGUID = $span->_traceGUID;
         $this->setTag("parent_span_guid", $span->guid());
         return $this;
     }

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -70,13 +70,13 @@ class SpanTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testStartSpanWithParent() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = LightStep::newTracer('test_group', '1234567890');
 
-        $parent = $tracer->startSpan("parent");
+        $parent = $tracer->startSpan('parent');
         $this->assertTrue(strlen($parent->traceGUID()) > 0);
         $this->assertTrue(strlen($parent->guid()) > 0);
 
-        $child = $tracer->startSpan("child", array(parent => $parent));
+        $child = $tracer->startSpan('child', array('parent' => $parent));
         $this->assertEquals($child->traceGUID(), $parent->traceGUID());
         $this->assertEquals($child->getParentGUID(), $parent->guid());
 
@@ -87,13 +87,13 @@ class SpanTest extends PHPUnit_Framework_TestCase {
     public function testSetParent() {
         // NOTE: setParent() is not part of the OpenTracing API. (Reminder this
         // is a unit test so non-API calls are ok!)
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = LightStep::newTracer('test_group', '1234567890');
 
-        $parent = $tracer->startSpan("parent");
+        $parent = $tracer->startSpan('parent');
         $this->assertTrue(strlen($parent->traceGUID()) > 0);
         $this->assertTrue(strlen($parent->guid()) > 0);
 
-        $child = $tracer->startSpan("child");
+        $child = $tracer->startSpan('child');
         $child->setParent($parent);
         $this->assertEquals($child->traceGUID(), $parent->traceGUID());
         $this->assertEquals($child->getParentGUID(), $parent->guid());


### PR DESCRIPTION
## Summary
- Fix defect where child span was not inheriting the parent trace GUID
- Add unit tests around the above bullet
- Add child span to the minimal example snippet
- Add the minimal example snippet as a runnable file as well as in the README
