### PR TITLE
Adding tags to the Thrift report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ intermediate/
 
 # Ignore only the top-level vendor directory
 /vendor/
+/tmp/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install_dependencies:
 
 .PHONY: test
 test:
-	phpunit --bootstrap vendor/autoload.php test
+	vendor/bin/phpunit
 
 .PHONY: docs
 docs:

--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -189,6 +189,15 @@ class ClientSpan implements \LightStepBase\Span {
             array_push($joinIds, $pair);
         }
 
+        $tags = array();
+        foreach ($this->_tags as $key => $value) {
+            $pair = new \CroutonThrift\KeyValue([
+                "Key" => strval($key),
+                "Value"    => strval($value),
+            ]);
+            array_push($tags, $pair);
+        }
+
         $rec = new \CroutonThrift\SpanRecord(array(
             "runtime_guid" => strval($this->_tracer->guid()),
             "span_guid" => strval($this->_guid),
@@ -198,6 +207,7 @@ class ClientSpan implements \LightStepBase\Span {
             "youngest_micros" => intval($this->_endMicros),
             "join_ids" => $joinIds,
             "error_flag" => $this->_errorFlag,
+            "attributes" => $tags,
         ));
         return $rec;
     }

--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -192,22 +192,22 @@ class ClientSpan implements \LightStepBase\Span {
         $tags = array();
         foreach ($this->_tags as $key => $value) {
             $pair = new \CroutonThrift\KeyValue([
-                "Key" => strval($key),
+                "Key"      => strval($key),
                 "Value"    => strval($value),
             ]);
             array_push($tags, $pair);
         }
 
         $rec = new \CroutonThrift\SpanRecord(array(
-            "runtime_guid" => strval($this->_tracer->guid()),
-            "span_guid" => strval($this->_guid),
-            "trace_guid" => strval($this->_traceGUID),
-            "span_name" => strval($this->_operation),
-            "oldest_micros" => intval($this->_startMicros),
+            "runtime_guid"    => strval($this->_tracer->guid()),
+            "span_guid"       => strval($this->_guid),
+            "trace_guid"      => strval($this->_traceGUID),
+            "span_name"       => strval($this->_operation),
+            "oldest_micros"   => intval($this->_startMicros),
             "youngest_micros" => intval($this->_endMicros),
-            "join_ids" => $joinIds,
-            "error_flag" => $this->_errorFlag,
-            "attributes" => $tags,
+            "join_ids"        => $joinIds,
+            "error_flag"      => $this->_errorFlag,
+            "attributes"      => $tags,
         ));
         return $rec;
     }

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -117,9 +117,9 @@ class SpanTest extends BaseLightStepTest {
         $this->assertTrue(is_string($arr["span_name"]));
         $this->assertEquals(1, count($arr["join_ids"]));
         $this->assertTrue(is_string($arr["join_ids"][0]["TraceKey"]));
-	$this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
-	$this->assertTrue(is_string($arr["attributes"][0]["Key"]));
-	$this->assertTrue(is_string($arr["attributes"][0]["Value"]));
+        $this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
+        $this->assertTrue(is_string($arr["attributes"][0]["Key"]));
+        $this->assertTrue(is_string($arr["attributes"][0]["Value"]));
     }
 
     public function testInjectJoin() {

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -105,7 +105,8 @@ class SpanTest extends BaseLightStepTest {
     public function testSpanThriftRecord() {
         $tracer = LightStep::newTracer("test_group", "1234567890");
         $span = $tracer->startSpan("hello/world");
-        $span->setEnduserId("dinosaur_sr");
+	$span->setEnduserId("dinosaur_sr");
+	$span->setTag("Titanosaurus", "sauropod");
         $span->finish();
 
         // Transform the object into a associative array
@@ -116,7 +117,9 @@ class SpanTest extends BaseLightStepTest {
         $this->assertTrue(is_string($arr["span_name"]));
         $this->assertEquals(1, count($arr["join_ids"]));
         $this->assertTrue(is_string($arr["join_ids"][0]["TraceKey"]));
-        $this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
+	$this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
+	$this->assertTrue(is_string($arr["attributes"][0]["Key"]));
+	$this->assertTrue(is_string($arr["attributes"][0]["Value"]));
     }
 
     public function testInjectJoin() {

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -105,9 +105,9 @@ class SpanTest extends BaseLightStepTest {
     public function testSpanThriftRecord() {
         $tracer = LightStep::newTracer("test_group", "1234567890");
         $span = $tracer->startSpan("hello/world");
-	$span->setEnduserId("dinosaur_sr");
-	$span->setTag("Titanosaurus", "sauropod");
-        $span->finish();
+        $span->setEnduserId("dinosaur_sr");
+        $span->setTag("Titanosaurus", "sauropod");
+        $span->finish();      
 
         // Transform the object into a associative array
         $arr = json_decode(json_encode($span->toThrift()), TRUE);


### PR DESCRIPTION
This is adding tags to the thrift report. PHP client library had a bug that it was not reporting tags. 
