### PR TITLE
Update tracer tag names to match the convention

### DIFF
--- a/lib/Client/ClientTracer.php
+++ b/lib/Client/ClientTracer.php
@@ -169,9 +169,9 @@ class ClientTracer implements \LightStepBase\Tracer {
 
         // Tracer attributes
         $runtimeAttrs = [
-            'lightstep_tracer_platform' => 'php',
-            'lightstep_tracer_version'  => LIGHTSTEP_VERSION,
-            'php_version' => phpversion(),
+            'lightstep.tracer_platform' => 'php',
+            'lightstep.tracer_platform_version' => phpversion(),
+            'lightstep.tracer_version'  => LIGHTSTEP_VERSION,
         ];
 
         // Generate the GUID on thrift initialization as the GUID should be


### PR DESCRIPTION
Trivial update to ensure the LightStep tracer tags match the current reporting convention.
