### PR TITLE
Fix Transport Option Select

### DIFF
--- a/lib/Client/ClientTracer.php
+++ b/lib/Client/ClientTracer.php
@@ -91,7 +91,7 @@ class ClientTracer implements \LightStepBase\Tracer {
 
         if ($this->_options['transport'] == 'udp') {
             $this->_transport = new Transports\TransportUDP();
-        } if ($this->_options['transport'] == 'http_proto') {
+        } else if ($this->_options['transport'] == 'http_proto') {
             $this->_transport = new Transports\TransportHTTPPROTO();
         } else {
             $this->_transport = new Transports\TransportHTTPJSON();

--- a/test/ClientTracerTest.php
+++ b/test/ClientTracerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use LightStepBase\Client\ClientTracer;
+use LightStepBase\Client\Transports\TransportHTTPJSON;
+use LightStepBase\Client\Transports\TransportHTTPPROTO;
+use LightStepBase\Client\Transports\TransportUDP;
+
+class ClientTracerTest extends BaseLightStepTest
+{
+
+    /**
+     * @dataProvider transports
+     */
+    public function testCorrectTransportSelected($key, $class)
+    {
+
+        $tracer = new ClientTracer(['transport' => $key]);
+
+        $this->assertInstanceOf($class, $this->readAttribute($tracer, '_transport'));
+    }
+
+    public function transports()
+    {
+
+        return [
+            'udp' => ['udp', TransportUDP::class],
+            'http_json' => ['http_json', TransportHTTPJSON::class],
+            'http_proto' => ['http_proto', TransportHTTPPROTO::class],
+        ];
+    }
+}


### PR DESCRIPTION
Just a quick fix of a type-o. Without the `else` prefix, the second `if` will only ever allow the transport to be `TransportHTTPPROTO` or `TransportHTTPJSON` since the second `if` will be treated as a new statement.