### PR TITLE
Allow a PSR logger set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,17 @@
     "require": {
         "ruafozy/mersenne-twister": "^1.3",
         "google/protobuf": ">=3.6.1",
-        "ext-bcmath": "*"
+        "ext-bcmath": "*",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "^2.8.5",
         "phpunit/phpunit": "~4.8.20"
     },
     "autoload": {
+        "psr-4": {
+            "LightStepBase\\": "lib"
+        },
         "files": [
             "lib/LightStep.php"
         ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cff8a6945ceba149d4cb4caacf70736e",
+    "content-hash": "04f440592fcd6622309aeb97cad254bb",
     "packages": [
         {
             "name": "google/protobuf",
@@ -46,6 +46,53 @@
                 "proto"
             ],
             "time": "2018-07-27T20:30:28+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "ruafozy/mersenne-twister",
@@ -1884,53 +1931,6 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -3868,6 +3868,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-bcmath": "*"
+    },
     "platform-dev": []
 }

--- a/lib/Client/SystemLogger.php
+++ b/lib/Client/SystemLogger.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace LightStepBase\Client;
+
+use Psr\Log\AbstractLogger;
+
+class SystemLogger extends AbstractLogger
+{
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        error_log($message . PHP_EOL . var_export($context, true));
+    }
+}

--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -1,11 +1,23 @@
 <?php
 namespace LightStepBase\Client\Transports;
 
+use LightStepBase\Client\SystemLogger;
+use Psr\Log\LoggerInterface;
+
 class TransportHTTPJSON {
 
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger = null) {
+
+        $this->logger = $logger ?: new SystemLogger;
+    }
 
     public function ensureConnection($options) {
         $this->_verbose = $options['verbose'];
@@ -22,7 +34,7 @@ class TransportHTTPJSON {
     public function flushReport($auth, $report) {
         if (is_null($auth) || is_null($report)) {
             if ($this->_verbose > 0) {
-                error_log("Auth or report not set.");
+                $this->logger->error("Auth or report not set.");
             }
             return NULL;
         }
@@ -30,7 +42,7 @@ class TransportHTTPJSON {
         $thriftReport = $report->toThrift();
 
         if ($this->_verbose >= 3) {
-            var_dump($thriftReport);
+            $this->logger->debug('report contents:', $thriftReport);
         }
 
         $content = json_encode($thriftReport);
@@ -48,7 +60,7 @@ class TransportHTTPJSON {
         $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr);
         if (!$fp) {
             if ($this->_verbose > 0) {
-                error_log($errstr);
+                $this->logger->error($errstr);
             }
             return NULL;
         }

--- a/lib/Client/Transports/TransportHTTPPROTO.php
+++ b/lib/Client/Transports/TransportHTTPPROTO.php
@@ -1,11 +1,23 @@
 <?php
 namespace LightStepBase\Client\Transports;
 
+use LightStepBase\Client\SystemLogger;
+use Psr\Log\LoggerInterface;
+
 class TransportHTTPPROTO {
 
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger = null) {
+
+        $this->logger = $logger ?: new SystemLogger;
+    }
 
     /**
      * Assigns the variables that are required for connectivity.
@@ -31,7 +43,7 @@ class TransportHTTPPROTO {
     public function flushReport($auth, $report) {
         if (is_null($auth) || is_null($report)) {
             if ($this->_verbose > 0) {
-                error_log("Auth or report not set.");
+                $this->logger->error("Auth or report not set.");
             }
             return NULL;
         }
@@ -39,8 +51,7 @@ class TransportHTTPPROTO {
         $content = $report->toProto($auth)->serializeToString();
 
         if ($this->_verbose >= 3) {
-            syslog(LOG_DEBUG, "Report to be flushed");
-            var_dump($content);
+            $this->logger->debug('Report to be flushed', ['content' => $content]);
         }
 
         $header = "Host: " . $this->_host . "\r\n";
@@ -54,7 +65,7 @@ class TransportHTTPPROTO {
         $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr);
         if (!$fp) {
             if ($this->_verbose > 0) {
-                error_log($errstr);
+                $this->logger->error($errstr);
             }
             return NULL;
         }

--- a/lib/Client/Transports/TransportUDP.php
+++ b/lib/Client/Transports/TransportUDP.php
@@ -1,6 +1,9 @@
 <?php
 namespace LightStepBase\Client\Transports;
 
+use LightStepBase\Client\SystemLogger;
+use Psr\Log\LoggerInterface;
+
 class TransportUDP {
 
     const MAX_MESSAGE_BYTES = 65535;
@@ -8,6 +11,15 @@ class TransportUDP {
     protected $_sock = NULL;
     protected $_host = NULL;
     protected $_post = NULL;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    public function __construct(LoggerInterface $logger = null) {
+
+        $this->logger = $logger ?: new SystemLogger;
+    }
 
     public function ensureConnection($options) {
         $sock = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
@@ -57,6 +69,7 @@ class TransportUDP {
 
         // Reset the connection if something went amiss
         if ($bytesSent === FALSE) {
+            $this->logger->error('Socket returned error code: ' . socket_last_error($this->_sock));
             socket_close($this->_sock);
             $this->_sock = NULL;
         }


### PR DESCRIPTION
By default, this library logs to the system log file defined in the php.ini file. However in a modern framework, that's not where a developer would expect to see their errors.

This PR introduces the FIG-PSR standard logging interface so that an application's logger can be passed in allowing the developer to more easily control where logs are recorded. To maintain the existing functionality, if no logger is provided, the `SystemLogger` will be used as the default.

```php
$tracer = LightStep::getInstance($options);
$trace->setLogger(new \Monolog\Logger('lightstep'));
```