### PR TITLE
Fixes early connection termination for proto over http

### DIFF
--- a/lib/Client/Transports/TransportHTTPPROTO.php
+++ b/lib/Client/Transports/TransportHTTPPROTO.php
@@ -73,6 +73,10 @@ class TransportHTTPPROTO {
         @fwrite($fp, "POST /api/v2/reports HTTP/1.1\r\n");
         @fwrite($fp, $header . $content);
         @fflush($fp);
+        // Wait and read first line of the response e.g. (HTTP/1.1 2xx OK)
+        // otherwise the connection will close before the request is complete,
+        // leading to a context cancellation down stream.
+        fgets($fp);
         @fclose($fp);
 
         return NULL;


### PR DESCRIPTION
Reviewers: @frenchfrywpepper @aliceadelef @sbaum1994 
Ticket: https://lightstep.atlassian.net/browse/LS-9879

By not waiting for the http response to come through (`HTTP/1.1 CODE DESCRIPTION`), the connection closes early, causing golang net.HTTP servers to cancel the request's context. This prevents the creation of new project reporters when using PHP in our satellite as the request context gets propagated to internal RPC calls. 