### PR TITLE
Fix hanging tests

### DIFF
--- a/test/BaseLightStepTest.php
+++ b/test/BaseLightStepTest.php
@@ -10,7 +10,7 @@ abstract class BaseLightStepTest extends PHPUnit_Framework_TestCase
 {
     protected function createTestTracer($component_name, $access_token) {
         $opts = [
-            "debug_disable_flush" => "true"
+            "debug_disable_flush" => TRUE
         ];
 
         return LightStep::newTracer("test_group", "1234567890", $opts);

--- a/test/BaseLightStepTest.php
+++ b/test/BaseLightStepTest.php
@@ -8,6 +8,14 @@
  */
 abstract class BaseLightStepTest extends PHPUnit_Framework_TestCase
 {
+    protected function createTestTracer($component_name, $access_token) {
+        $opts = [
+            "debug_disable_flush" => "true"
+        ];
+
+        return LightStep::newTracer("test_group", "1234567890", $opts);
+	}
+
     /**
      * Helper to grab protected fields -- useful for the unit tests!
      *

--- a/test/InitializationTest.php
+++ b/test/InitializationTest.php
@@ -7,7 +7,10 @@ class InitializationTest extends BaseLightStepTest {
         completed, the runtime should buffer that data until the init call.
      */
     public function testOutOfOrderInitializationDoesntFail() {
-        $runtime = LightStep::newTracer(NULL, NULL);
+        $opts = [
+            "debug_disable_flush" => "true"
+        ];
+        $runtime = LightStep::newTracer(NULL, NULL, $opts);
         $span = $runtime->startSpan("test_span");
         $span->infof("log000");
 
@@ -25,7 +28,10 @@ class InitializationTest extends BaseLightStepTest {
     }
 
     public function testMultipleInitCalls() {
-        $runtime = LightStep::newTracer(NULL, NULL);
+        $opts = [
+            "debug_disable_flush" => "true"
+        ];
+        $runtime = LightStep::newTracer(NULL, NULL, $opts);
         $span = $runtime->startSpan("test_span");
 
         $this->assertGreaterThan(0, $this->peek($runtime, "_options")['max_log_records']);
@@ -47,7 +53,10 @@ class InitializationTest extends BaseLightStepTest {
     }
 
     public function testSpanBufferingBeforeInit() {
-        $runtime = LightStep::newTracer(NULL, NULL);
+        $opts = [
+            "debug_disable_flush" => "true"
+        ];
+        $runtime = LightStep::newTracer(NULL, NULL, $opts);
         $span = $runtime->startSpan("first");
         $span->infof('Hello %s', 'World');
         $span->finish();

--- a/test/PayloadsTest.php
+++ b/test/PayloadsTest.php
@@ -12,7 +12,7 @@ class TestClass001 {
 class PayloadsTest extends BaseLightStepTest {
 
     public function testDataTypes() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
+        $runtime = $this->createTestTracer("test_group", "1234567890");
         $span = $runtime->startSpan('test_span');
         $span->infof("This doesn't have a payload");
 
@@ -55,7 +55,7 @@ class PayloadsTest extends BaseLightStepTest {
     }
 
     public function testDataTypes2() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
+        $runtime = $this->createTestTracer("test_group", "1234567890");
         $span = $runtime->startSpan('test_span');
 
         $span->infof("This doesn't have a payload");
@@ -100,7 +100,7 @@ class PayloadsTest extends BaseLightStepTest {
     }
 
     public function testCircularReferences() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
+        $runtime = $this->createTestTracer("test_group", "1234567890");
         $span = $runtime->startSpan('test_span');
 
         $a = array('next' => null);
@@ -122,7 +122,7 @@ class PayloadsTest extends BaseLightStepTest {
     }
 
     public function testDeeplyNested() {
-        $runtime = LightStep::newTracer("test_group", "1234567890");
+        $runtime = $this->createTestTracer("test_group", "1234567890");
         $span = $runtime->startSpan('test_span');
         $span->infof("test", $this->_wrapValue("value!", 2));
         $span->infof("test", $this->_wrapValue("value!", 4));

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -3,7 +3,7 @@
 class SpanTest extends BaseLightStepTest {
 
     public function testSpanSetOperation() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("server/query");
         $span->finish();
 
@@ -11,7 +11,7 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testSpanStartEndMicros() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
 
         $sum = 0;
         for ($i = 0; $i < 50; $i++) {
@@ -35,7 +35,7 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testSpanJoinIds() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("join_id_span");
 
         $span->addTraceJoinId("number", "one");
@@ -46,7 +46,7 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testSpanLogging() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("log_span");
         $span->infof("Test %d %f %s", 1, 2.0, "three");
         $span->warnf("Test %d %f %s", 1, 2.0, "three");
@@ -55,7 +55,7 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testSpanAttributes() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("attributes_span");
         $span->setTag("test_attribute_1", "value 1");
         $span->setTag("test_attribute_2", "value 2");
@@ -70,7 +70,7 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testStartSpanWithParent() {
-        $tracer = LightStep::newTracer('test_group', '1234567890');
+        $tracer = $this->createTestTracer("test_group", "1234567890");
 
         $parent = $tracer->startSpan('parent');
         $this->assertTrue(strlen($parent->traceGUID()) > 0);
@@ -87,7 +87,7 @@ class SpanTest extends BaseLightStepTest {
     public function testSetParent() {
         // NOTE: setParent() is not part of the OpenTracing API. (Reminder this
         // is a unit test so non-API calls are ok!)
-        $tracer = LightStep::newTracer('test_group', '1234567890');
+        $tracer = $this->createTestTracer("test_group", "1234567890");
 
         $parent = $tracer->startSpan('parent');
         $this->assertTrue(strlen($parent->traceGUID()) > 0);
@@ -103,11 +103,11 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testSpanThriftRecord() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("hello/world");
         $span->setEnduserId("dinosaur_sr");
         $span->setTag("Titanosaurus", "sauropod");
-        $span->finish();      
+        $span->finish();
 
         // Transform the object into a associative array
         $arr = json_decode(json_encode($span->toThrift()), TRUE);
@@ -123,7 +123,7 @@ class SpanTest extends BaseLightStepTest {
     }
 
     public function testInjectJoin() {
-        $tracer = LightStep::newTracer("test_group", "1234567890");
+        $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("hello/world");
 
         $carrier = array();


### PR DESCRIPTION
Resolves #30.

Some tests were failing because the default transport _http_json_ tries to publish spans to public LightStep satelillites but does not provide a valid access token so timeout / fail.

This change introduces a `createTestTracer` function in **BaseLightStepTest** that creates a tracer with flush disabled.

NOTE: InitializationTests still use a custom tracer, but still disables flushing.