### PR TITLE
Add support for custom tracer attributes

### DIFF
--- a/lib/Client/ClientTracer.php
+++ b/lib/Client/ClientTracer.php
@@ -97,7 +97,7 @@ class ClientTracer implements \LightStepBase\Tracer, LoggerAwareInterface {
             $defaults['max_span_records'] = 16;
         }
 
-        // combine default and custom trsacer attributes
+        // combine default and custom tracer attributes
         if (isset($options['attributes'])) {
             $options['attributes'] = array_merge($defaults['attributes'], $options['attributes']);
         }

--- a/test/ClientTracerTest.php
+++ b/test/ClientTracerTest.php
@@ -28,4 +28,64 @@ class ClientTracerTest extends BaseLightStepTest
             'http_proto' => ['http_proto', TransportHTTPPROTO::class],
         ];
     }
+
+    public function testDefaultTracerAttributesAreAdded() {
+        $opts = [
+            'component_name' => 'test_group',
+            'access_token' => '1234567890',
+            'debug_disable_flush' => TRUE
+        ];
+        $tracer = new ClientTracer($opts);
+        $attributes = $this->peek($tracer, '_options')['attributes'];
+
+        $this->assertArrayHasKey('lightstep.tracer_platform', $attributes);
+        $this->assertSame('php', $attributes['lightstep.tracer_platform']);
+
+        $this->assertArrayHasKey('lightstep.tracer_platform_version', $attributes);
+        $this->assertSame(phpversion(), $attributes['lightstep.tracer_platform_version']);
+
+        $this->assertArrayHasKey('lightstep.tracer_version', $attributes);
+        $this->assertSame(LIGHTSTEP_VERSION, $attributes['lightstep.tracer_version']);
+    }
+
+    public function testSettingCustomTracerAttributes() {
+        $opts = [
+            'component_name' => 'test_group',
+            'access_token' => '1234567890',
+            'debug_disable_flush' => TRUE,
+            'attributes' => [
+                'foo' => 'bar'
+            ]
+        ];
+        $tracer = new ClientTracer($opts);
+        $attributes = $this->peek($tracer, '_options')['attributes'];
+
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertSame($attributes['foo'], 'bar');
+    }
+
+    public function testAddingCustomAttributeDoesNotRemoveDefaultAttributes() {
+        $opts = [
+            'component_name' => 'test_group',
+            'access_token' => '1234567890',
+            'debug_disable_flush' => TRUE,
+            'attributes' => [
+                'foo' => 'bar'
+            ]
+        ];
+        $tracer = new ClientTracer($opts);
+        $attributes = $this->peek($tracer, '_options')['attributes'];
+
+        $this->assertArrayHasKey('lightstep.tracer_platform', $attributes);
+        $this->assertSame('php', $attributes['lightstep.tracer_platform']);
+
+        $this->assertArrayHasKey('lightstep.tracer_platform_version', $attributes);
+        $this->assertSame(phpversion(), $attributes['lightstep.tracer_platform_version']);
+
+        $this->assertArrayHasKey('lightstep.tracer_version', $attributes);
+        $this->assertSame(LIGHTSTEP_VERSION, $attributes['lightstep.tracer_version']);
+
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertSame($attributes['foo'], 'bar');
+    }
 }


### PR DESCRIPTION
Resolves #27.

Allows adding custom tracer level attributes by adding `attributes` to options.