### PR TITLE
Correctly set Host header when sending over ssl://

### DIFF
--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -28,7 +28,7 @@ class TransportHTTPJSON {
 
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == True) {
-            $this->_scheme = "ssl://";
+            $this->_scheme = 'tls://';
         }
     }
 

--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 
 class TransportHTTPJSON {
 
+    protected $_scheme = '';
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
@@ -27,7 +28,7 @@ class TransportHTTPJSON {
 
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == True) {
-            $this->_host = "ssl://" . $this->_host;
+            $this->_scheme = "ssl://";
         }
     }
 
@@ -57,7 +58,7 @@ class TransportHTTPJSON {
         $header .= "Connection: keep-alive\r\n\r\n";
 
         // Use a persistent connection when possible
-        $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr);
+        $fp = @pfsockopen($this->_scheme . $this->_host, $this->_port, $errno, $errstr);
         if (!$fp) {
             if ($this->_verbose > 0) {
                 $this->logger->error($errstr);


### PR DESCRIPTION
Fixes #35 

When sending requests over HTTPS, the Host header should not include the URL scheme or it will be rejected with a 400 (Bad request) by the Collector.

This update fixes the HTTP JSON transport to not prefix the scheme the host header which allows the request to succeed.

Also, the default scheme has been updated to use TLS over SSL as it's generally regarded as more secure.

Filed #40 to add support for better managing the selected scheme.