### PR TITLE
Fix http_proto transport to work over HTTPS

### DIFF
--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -28,7 +28,7 @@ class TransportHTTPJSON {
 
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == True) {
-            $this->_scheme = "ssl://";
+            $this->_scheme = 'tls://';
         }
     }
 

--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 
 class TransportHTTPJSON {
 
+    protected $_scheme = '';
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
@@ -27,7 +28,7 @@ class TransportHTTPJSON {
 
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == True) {
-            $this->_host = "ssl://" . $this->_host;
+            $this->_scheme = "ssl://";
         }
     }
 
@@ -57,7 +58,7 @@ class TransportHTTPJSON {
         $header .= "Connection: keep-alive\r\n\r\n";
 
         // Use a persistent connection when possible
-        $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr);
+        $fp = @pfsockopen($this->_scheme . $this->_host, $this->_port, $errno, $errstr);
         if (!$fp) {
             if ($this->_verbose > 0) {
                 $this->logger->error($errstr);

--- a/lib/Client/Transports/TransportHTTPPROTO.php
+++ b/lib/Client/Transports/TransportHTTPPROTO.php
@@ -37,7 +37,7 @@ class TransportHTTPPROTO {
 
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == true) {
-            $this->_scheme = 'ssl://';
+            $this->_scheme = 'tls://';
         }
     }
 

--- a/lib/Client/Transports/TransportHTTPPROTO.php
+++ b/lib/Client/Transports/TransportHTTPPROTO.php
@@ -6,6 +6,7 @@ use Psr\Log\LoggerInterface;
 
 class TransportHTTPPROTO {
 
+    protected $_scheme = '';
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
@@ -36,7 +37,7 @@ class TransportHTTPPROTO {
 
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == true) {
-            $this->_host = "ssl://" . $this->_host;
+            $this->_scheme = 'ssl://';
         }
     }
 
@@ -62,7 +63,7 @@ class TransportHTTPPROTO {
         $header .= "Connection: keep-alive\r\n\r\n";
 
         // Use a persistent connection when possible
-        $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr);
+        $fp = @pfsockopen($this->_scheme . $this->_host, $this->_port, $errno, $errstr);
         if (!$fp) {
             if ($this->_verbose > 0) {
                 $this->logger->error($errstr);


### PR DESCRIPTION
Fixes #17.

Similar to #39, the same issue with the Host header including the url scheme was causing the collector to reject the request.

This PR also update the default scheme to use TLS.