### PR TITLE
Wait for response before closing connection in http_json

### DIFF
--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -68,6 +68,10 @@ class TransportHTTPJSON {
         @fwrite($fp, "POST /api/v0/reports HTTP/1.1\r\n");
         @fwrite($fp, $header . $content);
         @fflush($fp);
+        // Wait and read first line of the response e.g. (HTTP/1.1 2xx OK)
+        // otherwise the connection will close before the request is complete,
+        // leading to a context cancellation down stream.
+        fgets($fp);
         @fclose($fp);
 
         return NULL;


### PR DESCRIPTION
The connection used to send data to a collector does not wait for a response in http_json before allowing the connection to be closed. This can lead to data being lost in transit.

The wait code (fgets) is taken from http_proto to make data sending consistent and also sets up both transports to support dealing with the response (#16).