### PR TITLE
Fix http_proto sending child spans

### DIFF
--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -289,7 +289,7 @@ class ClientSpan implements \LightStepBase\Span {
 
         $ts = new Timestamp([
             'seconds' => floor($this->_startMicros / 1000000),
-            'nanos' => $this->_startMicros % 1000000,
+            'nanos' => ($this->_startMicros % 1000000) * 100,
         ]);
 
         $tags = [];

--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -311,12 +311,13 @@ class ClientSpan implements \LightStepBase\Span {
 
         $references = [];
         if ($this->getParentGUID() != NULL) {
-            $spanContext = new SpanContext([
+            $parentSpanContext = new SpanContext([
+                'trace_id' => Util::hexdec($this->traceGUID()),
                 'span_id' => Util::hexdec($this->getParentGUID())
             ]);
 
             $ref = new Reference([
-                'span_context' => $spanContext,
+                'span_context' => $parentSpanContext,
                 'relationship' => Relationship::CHILD_OF
             ]);
             $references[] = $ref;

--- a/test/ProtoTypesTest.php
+++ b/test/ProtoTypesTest.php
@@ -38,7 +38,7 @@ class ProtoTypesTest extends BaseLightStepTest {
 
         $this->assertEquals("my_operation", $protoSpan->getOperationName());
         $this->assertEquals(1538476581, $protoSpan->getStartTimestamp()->getSeconds());
-        $this->assertEquals(123456, $protoSpan->getStartTimestamp()->getNanos());
+        $this->assertEquals(12345600, $protoSpan->getStartTimestamp()->getNanos());
         $this->assertEquals(1000, $protoSpan->getDurationMicros());
 
         $references = $protoSpan->getReferences();
@@ -210,7 +210,7 @@ class ProtoTypesTest extends BaseLightStepTest {
 
         $this->assertEquals("my_operation", $protoSpan->getOperationName());
         $this->assertEquals(1538476581, $protoSpan->getStartTimestamp()->getSeconds());
-        $this->assertEquals(123456, $protoSpan->getStartTimestamp()->getNanos());
+        $this->assertEquals(12345600, $protoSpan->getStartTimestamp()->getNanos());
         $this->assertEquals(1000, $protoSpan->getDurationMicros());
 
         $references = $protoSpan->getReferences();


### PR DESCRIPTION
Fixes #36.

This PR allows child spans to be seen in the LightStep App. Child spans were not visible previously because the same span ID was used for all span's within the same trace, so only the parent was reported correctly.

After allowing spans to be reported, it was seen that parent and all child spans had the same start time. This was because the calculation from micros to nanos was incorrect.

The following fixes are included:
- create separate SpanContext for parent span context when creating parent reference
- correct micro to nano calculation

This also raised the issue of PHP not supporting unsigned int 64's (even int 64 can't be guaranteed). Further details in #43.