### PR TITLE
Allow connection timeout configuration for HTTP

### DIFF
--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -10,6 +10,8 @@ class TransportHTTPJSON {
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
+    protected $_timeout = null;
+
     /**
      * @var LoggerInterface
      */
@@ -29,6 +31,10 @@ class TransportHTTPJSON {
         // The prefixed protocol is only needed for secure connections
         if ($options['collector_secure'] == True) {
             $this->_scheme = 'tls://';
+        }
+
+        if (isset($options['http_connection_timeout'])) {
+            $this->_timeout = $options['http_connection_timeout'];
         }
     }
 
@@ -58,7 +64,7 @@ class TransportHTTPJSON {
         $header .= "Connection: keep-alive\r\n\r\n";
 
         // Use a persistent connection when possible
-        $fp = @pfsockopen($this->_scheme . $this->_host, $this->_port, $errno, $errstr);
+        $fp = @pfsockopen($this->_scheme . $this->_host, $this->_port, $errno, $errstr, $this->_timeout);
         if (!$fp) {
             if ($this->_verbose > 0) {
                 $this->logger->error($errstr);

--- a/lib/Client/Transports/TransportHTTPJSON.php
+++ b/lib/Client/Transports/TransportHTTPJSON.php
@@ -10,7 +10,7 @@ class TransportHTTPJSON {
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
-    protected $_timeout = null;
+    protected $_timeout;
 
     /**
      * @var LoggerInterface
@@ -20,6 +20,7 @@ class TransportHTTPJSON {
     public function __construct(LoggerInterface $logger = null) {
 
         $this->logger = $logger ?: new SystemLogger;
+        $this->_timeout = ini_get("default_socket_timeout");
     }
 
     public function ensureConnection($options) {

--- a/lib/Client/Transports/TransportHTTPPROTO.php
+++ b/lib/Client/Transports/TransportHTTPPROTO.php
@@ -9,7 +9,7 @@ class TransportHTTPPROTO {
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
-    protected $_timeout = null;
+    protected $_timeout;
 
     /**
      * @var LoggerInterface
@@ -19,6 +19,7 @@ class TransportHTTPPROTO {
     public function __construct(LoggerInterface $logger = null) {
 
         $this->logger = $logger ?: new SystemLogger;
+        $this->_timeout = ini_get("default_socket_timeout");
     }
 
     /**

--- a/lib/Client/Transports/TransportHTTPPROTO.php
+++ b/lib/Client/Transports/TransportHTTPPROTO.php
@@ -9,6 +9,8 @@ class TransportHTTPPROTO {
     protected $_host = '';
     protected $_port = 0;
     protected $_verbose = 0;
+    protected $_timeout = null;
+
     /**
      * @var LoggerInterface
      */
@@ -38,6 +40,10 @@ class TransportHTTPPROTO {
         if ($options['collector_secure'] == true) {
             $this->_host = "ssl://" . $this->_host;
         }
+
+        if (isset($options['http_connection_timeout'])) {
+            $this->_timeout = $options['http_connection_timeout'];
+        }
     }
 
     public function flushReport($auth, $report) {
@@ -62,7 +68,7 @@ class TransportHTTPPROTO {
         $header .= "Connection: keep-alive\r\n\r\n";
 
         // Use a persistent connection when possible
-        $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr);
+        $fp = @pfsockopen($this->_host, $this->_port, $errno, $errstr, $this->_timeout);
         if (!$fp) {
             if ($this->_verbose > 0) {
                 $this->logger->error($errstr);


### PR DESCRIPTION
In some certain case if the ip/fqdn and port is not answering, lightstep lib could hang for the default timeout in PHP (normally 60sec). This allow to configure timeout.