### PR TITLE
Connect to collector over secure port by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ LightStep::initGlobalTracer('examples/trivial_process', '{your_access_token}', [
 ]);
 ```
 
+By default the the tracer sends trace data securely to the public LightStep satellites at `collector.lightstep.com` over port `443` using TLS.
+
 ## Developer Setup
 
 ```bash

--- a/lib/Client/ClientTracer.php
+++ b/lib/Client/ClientTracer.php
@@ -55,8 +55,8 @@ class ClientTracer implements \LightStepBase\Tracer, LoggerAwareInterface {
 
         $defaults = [
             'collector_host'            => 'collector.lightstep.com',
-            'collector_port'            => 80,
-            'collector_secure'          => false,
+            'collector_port'            => 443,
+            'collector_secure'          => true,
 
             'transport'                 => 'http_json',
             'max_log_records'           => 1000,

--- a/test/ClientTracerTest.php
+++ b/test/ClientTracerTest.php
@@ -97,7 +97,6 @@ class ClientTracerTest extends BaseLightStepTest
                 'component_name' => 'test_group',
                 'access_token' => '1234567890',
                 'debug_disable_flush' => TRUE,
-                'collector_secure' => true,
                 'transport' => $transportType
             ];
             $tracer = new ClientTracer($opts);
@@ -107,6 +106,8 @@ class ClientTracerTest extends BaseLightStepTest
 
             $scheme = $this->peek($transport, '_scheme');
             $this->assertSame('tls://', $scheme);
+            $port = $this->peek($transport, '_port');
+            $this->assertSame(443, $port);
         }
     }
 
@@ -119,7 +120,6 @@ class ClientTracerTest extends BaseLightStepTest
                 'component_name' => 'test_group',
                 'access_token' => '1234567890',
                 'debug_disable_flush' => TRUE,
-                'collector_secure' => true,
                 'collector_scheme' => $expectedScheme,
                 'transport' => $transportType
             ];
@@ -130,6 +130,29 @@ class ClientTracerTest extends BaseLightStepTest
 
             $scheme = $this->peek($transport, '_scheme');
             $this->assertSame($expectedScheme, $scheme);
+        }
+    }
+
+    public function testSendDataInPlainText() {
+        $transports = ['http_json', 'http_proto'];
+
+        foreach ($transports as $transportType) {
+            $opts = [
+                'component_name' => 'test_group',
+                'access_token' => '1234567890',
+                'debug_disable_flush' => TRUE,
+                'transport' => $transportType,
+                'collector_secure' => FALSE
+            ];
+            $tracer = new ClientTracer($opts);
+            $transport = $this->peek($tracer, '_transport');
+            $tracerOptions = $this->peek($tracer, '_options');
+            $transport->ensureConnection($tracerOptions);
+
+            $scheme = $this->peek($transport, '_scheme');
+            $this->assertSame('', $scheme); //pfsockopen uses http:// when empty
+            $port = $this->peek($transport, '_port');
+            $this->assertSame(80, $port);
         }
     }
 }


### PR DESCRIPTION
Changes:
- default collector_secure to true
- default collector_port to 443
- update default config test to check for tls:// and port 443
- add test to check tracer can run in plain text mode