### PR TITLE
Breaking changes to bring tracer up to spec with latest API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/php:5-node-browsers
+      - image: circleci/php:7.1-node-browsers
     steps:
       - checkout
       - restore_cache:

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,11 @@
     "description": "LightStep instrumentation API",
     "license": "MIT",
     "require": {
-        "ruafozy/mersenne-twister": "^1.3",
-        "google/protobuf": ">=3.6.1",
         "ext-bcmath": "*",
-        "psr/log": "^1.0"
+        "google/protobuf": ">=3.6.1",
+        "opentracing/opentracing": "^1.0.0-beta6",
+        "psr/log": "^1.0",
+        "ruafozy/mersenne-twister": "^1.3"
     },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "^2.8.5",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "LightStep instrumentation API",
     "license": "MIT",
     "require": {
+        "php": "^7.1",
         "ext-bcmath": "*",
         "google/protobuf": ">=3.6.1",
         "opentracing/opentracing": "^1.0.0-beta6",

--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -6,12 +6,11 @@ use Lightstep\Collector\Reference\Relationship;
 use Lightstep\Collector\Span;
 use Lightstep\Collector\SpanContext;
 use Google\Protobuf\Timestamp;
-use LightStepBase\Tracer;
 
 require_once(dirname(__FILE__) . "/Util.php");
 require_once(dirname(__FILE__) . "/../../thrift/CroutonThrift/Types.php");
 
-class ClientSpan implements \LightStepBase\Span {
+class ClientSpan implements \OpenTracing\Span {
 
     protected $_tracer = NULL;
 
@@ -76,22 +75,30 @@ class ClientSpan implements \LightStepBase\Span {
         return $this;
     }
 
-    public function finish() {
-        $this->_tracer->_finishSpan($this);
+    public function getOperationName() {
+        return $this->_operation;
     }
 
-    public function setOperationName($name) {
+    public function getContext() {
+        return new ClientSpanContext(
+            $this->traceGUID(),
+            $this->guid(),
+            true,
+            $this->getBaggage()
+        );
+    }
+
+    public function finish($finishTime = NULL) {
+        $this->_tracer->_finishSpan($this, $finishTime);
+    }
+
+    public function overwriteOperationName($name) {
         $this->_operation = $name;
         return $this;
     }
 
     public function addTraceJoinId($key, $value) {
         $this->_joinIds[$key] = $value;
-        return $this;
-    }
-
-    public function setEndUserId($id) {
-        $this->addTraceJoinId(LIGHTSTEP_JOIN_KEY_END_USER_ID, $id);
         return $this;
     }
 
@@ -107,7 +114,7 @@ class ClientSpan implements \LightStepBase\Span {
         return $this;
     }
 
-    public function setBaggageItem($key, $value) {
+    public function addBaggageItem($key, $value) {
         $this->_baggage[$key] = $value;
         return $this;
     }
@@ -153,7 +160,7 @@ class ClientSpan implements \LightStepBase\Span {
         ]);
     }
 
-    public function log($fields) {
+    public function log(array $fields = [], $timestamp = NULL) {
         $record = [
             'span_guid' => strval($this->_guid),
         ];
@@ -163,7 +170,9 @@ class ClientSpan implements \LightStepBase\Span {
             $record['event'] = strval($fields['event']);
         }
 
-        if (!empty($fields['timestamp'])) {
+        if ($timestamp) {
+            $record['timestamp_micros'] = intval(1000 * $timestamp);
+        } else if (!empty($fields['timestamp'])) {
             $record['timestamp_micros'] = intval(1000 * $fields['timestamp']);
         }
         // no need to verify value of fields['payload'] as it will be checked by _rawLogRecord
@@ -332,5 +341,11 @@ class ClientSpan implements \LightStepBase\Span {
             'logs' => $logs,
             'references' => $references,
         ]);
+    }
+
+    /** Deprecated */
+    public function setEndUserId($id) {
+        $this->addTraceJoinId("LIGHTSTEP_JOIN_KEY_END_USER_ID", $id);
+        return $this;
     }
 }

--- a/lib/Client/ClientSpanContext.php
+++ b/lib/Client/ClientSpanContext.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LightStepBase\Client;
+
+use ArrayIterator;
+
+class ClientSpanContext implements \OpenTracing\SpanContext {
+    /**
+     * @var string
+     */
+    private $traceId;
+
+    /**
+     * @var string
+     */
+    private $spanId;
+
+    /**
+     * @var bool
+     */
+    private $isSampled;
+
+    /**
+     * @var array
+     */
+    private $baggageItems;
+
+    public function __construct(string $traceId, string $spanId, bool $isSampled = true, array $baggageItems = [])
+    {
+        $this->traceId = $traceId;
+        $this->spanId = $spanId;
+        $this->isSampled = $isSampled;
+        $this->baggageItems = $baggageItems;
+    }
+
+    public function getTraceId(): string
+    {
+        return $this->traceId;
+    }
+
+    public function getSpanId(): string
+    {
+        return $this->spanId;
+    }
+
+    public function isSampled(): bool
+    {
+        return $this->isSampled;
+    }
+
+    public function getBaggage(): array
+    {
+        return $this->baggageItems;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->baggageItems);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaggageItem($key): ?string
+    {
+        return array_key_exists($key, $this->baggageItems) ? strval($this->baggageItems[$key]) : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withBaggageItem($key, $value): ?SpanContext
+    {
+        return new self($this->traceId, $this->spanId, $this->isSampled, array_merge($this->bagaggeItems, [$key => $value]));
+    }
+
+}

--- a/lib/Client/NoOpSpan.php
+++ b/lib/Client/NoOpSpan.php
@@ -4,31 +4,32 @@ namespace LightStepBase\Client;
 require_once(dirname(__FILE__) . "/Util.php");
 require_once(dirname(__FILE__) . "/../../thrift/CroutonThrift/Types.php");
 
-class NoOpSpan implements \LightStepBase\Span {
+class NoOpSpan implements \OpenTracing\Span {
     public function guid() { return ""; }
     public function setRuntimeGUID($guid) {}
     public function traceGUID() { return ""; }
     public function setTraceGUID($traceGUID) {}
 
-    public function setOperationName($name) {}
+    public function overwriteOperationName($name) {}
     public function addTraceJoinId($key, $value) {}
 
     public function setEndUserId($id) {}
+    public function getContext() {}
+    public function getOperationName() {}
 
     public function tracer() { return LightStep::getInstance(); }
     public function setTag($key, $value) {}
-    public function setBaggageItem($key, $value) {}
+    public function addBaggageItem($key, $value) {}
     public function getBaggageItem($key) {}
     public function getBaggage() { return []; }
 
     public function logEvent($event, $payload = NULL) {}
-    public function log($fields) {}
+    public function log(array $fields = [], $timestamp = NULL) {}
 
     public function setParent($span) {}
     public function setParentGUID($parentGUID) {}
 
-
-    public function finish() {}
+    public function finish($finishTime = NULL) {}
 
     public function infof($fmt) {}
     public function warnf($fmt) {}

--- a/lib/LightStep.php
+++ b/lib/LightStep.php
@@ -1,6 +1,7 @@
 <?php
 
-use LightStepBase\Span;
+//use LightStepBase\Span;
+use OpenTracing\Span;
 
 require_once(__DIR__ . '/vendor/Thrift/Type/TType.php');
 require_once(__DIR__ . '/Client/ClientTracer.php');
@@ -33,7 +34,7 @@ class LightStep {
      * in library code with more than possible first entry-point, this may
      * be helpful.
      *
-     * @return \LightStepBase\Tracer
+     * @return \OpenTracing\Tracer
      * @throws Exception if the component name or access token is not a valid string
      * @throws Exception if the tracer singleton has already been initialized
      */
@@ -71,7 +72,7 @@ class LightStep {
      *
      * @param $component_name Component name to use for the tracer
      * @param $access_token The project access token
-     * @return \LightStepBase\Tracer
+     * @return \OpenTracing\Tracer
      * @throws Exception if the group name or access token is not a valid string
      */
     public static function getInstance($component_name = NULL, $access_token = NULL, $opts = NULL) {
@@ -87,7 +88,7 @@ class LightStep {
      *
      * @param $component_name Component name to use for the tracer
      * @param $access_token The project access token
-     * @return \LightStepBase\Tracer
+     * @return \OpenTracing\Tracer
      * @throws Exception if the group name or access token is not a valid string.
      */
     public static function newTracer ($component_name, $access_token, $opts = NULL) {
@@ -112,7 +113,7 @@ class LightStep {
      */
 
     /**
-     * @return \LightStepBase\Span
+     * @return \OpenTracing\Span
      */
     public static function startSpan($operationName, $fields = NULL) {
         return self::getInstance()->startSpan($operationName, $fields);

--- a/test/ProtoTypesTest.php
+++ b/test/ProtoTypesTest.php
@@ -17,7 +17,7 @@ class ProtoTypesTest extends BaseLightStepTest {
     public function testClientSpanToProto() {
         $tracer = new \LightStepBase\Client\ClientTracer();
         $span = new \LightStepBase\Client\ClientSpan($tracer, 5);
-        $span->setOperationName("my_operation");
+        $span->overwriteOperationName("my_operation");
         $span->setStartMicros(1538476581123456);
         $span->setEndMicros(1538476581124456);
         $span->setParentGUID("513887a3b3f460d8");
@@ -147,7 +147,7 @@ class ProtoTypesTest extends BaseLightStepTest {
 
         $tracer = new \LightStepBase\Client\ClientTracer();
         $span = new \LightStepBase\Client\ClientSpan($tracer, 5);
-        $span->setOperationName("my_operation");
+        $span->overwriteOperationName("my_operation");
         $span->setStartMicros(1538476581123456);
         $span->setEndMicros(1538476581124456);
         $span->setParentGUID("513887a3b3f460d8");

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -2,12 +2,23 @@
 
 class SpanTest extends BaseLightStepTest {
 
-    public function testSpanSetOperation() {
+    public function testSpanGetOperation() {
         $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("server/query");
         $span->finish();
 
-        $this->assertEquals($this->peek($span, "_operation"), "server/query");
+        $this->assertEquals($span->getOperationName(), "server/query");
+    }
+
+    public function testSpanOverwriteOperation() {
+        $tracer = $this->createTestTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("server/query");
+        $this->assertEquals($span->getOperationName(), "server/query");
+        
+        $span->overwriteOperationName("client/query");
+        $this->assertEquals($span->getOperationName(), "client/query");
+        
+        $span->finish();
     }
 
     public function testSpanStartEndMicros() {
@@ -32,18 +43,9 @@ class SpanTest extends BaseLightStepTest {
         // a lot of precision from usleep() here.
         $this->assertGreaterThan(100, $avg);
         $this->assertLessThan(1000, $avg);
-    }
+    } 
 
-    public function testSpanJoinIds() {
-        $tracer = $this->createTestTracer("test_group", "1234567890");
-        $span = $tracer->startSpan("join_id_span");
-
-        $span->addTraceJoinId("number", "one");
-        $this->assertEquals(count($this->peek($span, "_joinIds")), 1);
-
-        $span->setEndUserId("mr_jones");
-        $this->assertEquals(count($this->peek($span, "_joinIds")), 2);
-    }
+    // TODO: Test span with explicit finish
 
     public function testSpanLogging() {
         $tracer = $this->createTestTracer("test_group", "1234567890");
@@ -54,15 +56,15 @@ class SpanTest extends BaseLightStepTest {
         $span->finish();
     }
 
-    public function testSpanAttributes() {
+    public function testSpanTags() {
         $tracer = $this->createTestTracer("test_group", "1234567890");
-        $span = $tracer->startSpan("attributes_span");
-        $span->setTag("test_attribute_1", "value 1");
-        $span->setTag("test_attribute_2", "value 2");
+        $span = $tracer->startSpan("tags_span");
+        $span->setTag("test_tag_1", "value 1");
+        $span->setTag("test_tag_2", "value 2");
 
         $this->assertEquals(count($this->peek($span, "_tags")), 2);
 
-        $span->setTag("test_attribute_3", "value 3");
+        $span->setTag("test_tag_3", "value 3");
 
         $this->assertEquals(count($this->peek($span, "_tags")), 3);
 
@@ -109,6 +111,21 @@ class SpanTest extends BaseLightStepTest {
         $parent->finish();
     }
 
+    public function testStartSpanWithParent2() {
+        $tracer = $this->createTestTracer("test_group", "1234567890");
+
+        $parent = $tracer->startSpan('parent');
+        $this->assertTrue(strlen($parent->traceGUID()) > 0);
+        $this->assertTrue(strlen($parent->guid()) > 0);
+
+        $child = $tracer->startSpan('child', array('child_of' => $parent));
+        $this->assertEquals($child->traceGUID(), $parent->traceGUID());
+        $this->assertEquals($child->getParentGUID(), $parent->guid());
+
+        $child->finish();
+        $parent->finish();
+    }
+
     public function testSetParent() {
         // NOTE: setParent() is not part of the OpenTracing API. (Reminder this
         // is a unit test so non-API calls are ok!)
@@ -130,7 +147,7 @@ class SpanTest extends BaseLightStepTest {
     public function testSpanThriftRecord() {
         $tracer = $this->createTestTracer("test_group", "1234567890");
         $span = $tracer->startSpan("hello/world");
-        $span->setEnduserId("dinosaur_sr");
+        //$span->setEnduserId("dinosaur_sr");
         $span->setTag("Titanosaurus", "sauropod");
         $span->finish();
 
@@ -140,11 +157,52 @@ class SpanTest extends BaseLightStepTest {
         $this->assertTrue(is_string($arr["trace_guid"]));
         $this->assertTrue(is_string($arr["runtime_guid"]));
         $this->assertTrue(is_string($arr["span_name"]));
-        $this->assertEquals(1, count($arr["join_ids"]));
-        $this->assertTrue(is_string($arr["join_ids"][0]["TraceKey"]));
-        $this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
         $this->assertTrue(is_string($arr["attributes"][0]["Key"]));
         $this->assertTrue(is_string($arr["attributes"][0]["Value"]));
+
+        // $this->assertEquals(1, count($arr["join_ids"]));
+        // $this->assertTrue(is_string($arr["join_ids"][0]["TraceKey"]));
+        // $this->assertTrue(is_string($arr["join_ids"][0]["Value"]));
+    }
+
+    public function testSpanContext() {
+        $tracer = $this->createTestTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("hello/world");
+        $span->finish();
+
+        $spanContext = $span->getContext();
+        $this->assertEquals($spanContext->getTraceId(), $span->traceGUID());
+        $this->assertEquals($spanContext->getSpanId(), $span->guid());
+        $this->assertTrue($spanContext->isSampled());
+        $this->assertEquals($spanContext->getBaggage(), array());
+    }
+
+    public function testSpanContextWithBaggage() {
+        $tracer = $this->createTestTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("hello/world");
+        $span->addBaggageItem("fruit", "apple");
+        $span->addBaggageItem("number", 5);
+        $span->addBaggageItem("boolean", true);
+        $span->finish();
+
+        $spanContext = $span->getContext();
+        $this->assertEquals(count($spanContext->getBaggage()), 3);
+        $this->assertEquals($spanContext->getBaggageItem("fruit"), "apple");
+        $this->assertEquals($spanContext->getBaggageItem("number"), 5);
+        $this->assertEquals($spanContext->getBaggageItem("boolean"), true);
+    }
+
+    /** Depreceated Tests (Due to Join not being a valid alternative to extract) */
+     
+    public function testSpanJoinIds() {
+        $tracer = $this->createTestTracer("test_group", "1234567890");
+        $span = $tracer->startSpan("join_id_span");
+
+        $span->addTraceJoinId("number", "one");
+        $this->assertEquals(count($this->peek($span, "_joinIds")), 1);
+
+        $span->setEndUserId("mr_jones");
+        $this->assertEquals(count($this->peek($span, "_joinIds")), 2);
     }
 
     public function testInjectJoin() {
@@ -152,13 +210,13 @@ class SpanTest extends BaseLightStepTest {
         $span = $tracer->startSpan("hello/world");
 
         $carrier = array();
-        $tracer->inject($span, LIGHTSTEP_FORMAT_TEXT_MAP, $carrier);
+        $tracer->inject($span->getContext(), \OpenTracing\Formats\TEXT_MAP, $carrier);
         $this->assertEquals($carrier['ot-tracer-spanid'], $span->guid());
         $this->assertEquals($carrier['ot-tracer-traceid'], $span->traceGUID());
         $this->assertEquals($carrier['ot-tracer-sampled'], 'true');
         $span->finish();
 
-        $child = $tracer->join('child', LIGHTSTEP_FORMAT_TEXT_MAP, $carrier);
+        $child = $tracer->join('child', \OpenTracing\Formats\TEXT_MAP, $carrier);
         $this->assertEquals($child->traceGUID(), $span->traceGUID());
         $this->assertEquals($child->getParentGUID(), $span->guid());
         $child->finish();


### PR DESCRIPTION
This tracer needs a lot of ❤️ Based on a first pass, adding a checklist of items that need to be done. Lots of breaking changes. 

- [x] Remove older copy of opentracing api
- [x] Update classes to implement the actual [OpenTracing PHP API](https://github.com/opentracing/opentracing-php) 
- [x] Implement SpanContext interface
- [x] Add getContext() to Span 
- [x] Add overwriteOperationName() to Span 
- [x] Update Inject in Tracer to use SpanContext instead of Span
- [x] Add Extract method in Tracer 
- [ ] Add support for B3/Stack Propagator
- [ ] Implement Scope interface
- [ ] Implement ScopeManager interface
- [ ] Update a lot of tracer dev dependencies (phpunit, etc)
- [ ] Update documentation to be compatible with OpenTracing Spec
- [x] Update PHP Version with compatble OpenTracing Version in CircleCI