### PR TITLE
adding flag for users to disable die() on fatalf behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Added the `setDieOnFatal` function to give users the ability log a fatal error without the runtime calling `die()`
+
 ### Added
 - A Changelog
 - A PSR logger can now be used

--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -24,6 +24,7 @@ class ClientSpan implements \LightStepBase\Span {
     protected $_endMicros = 0;
     protected $_errorFlag = false;
     protected $_runtimeGUID = "";
+    protected $_dieOnFatal = true;
 
     protected $_joinIds = [];
     protected $_logRecords = [];
@@ -189,7 +190,14 @@ class ClientSpan implements \LightStepBase\Span {
     public function fatalf($fmt) {
         $this->_errorFlag = true;
         $text = $this->_log('F', true, $fmt, func_get_args());
-        die($text);
+        if ($this->_dieOnFatal) {
+            die($text);
+        }
+        return $this;
+    }
+
+    public function setDieOnFatal($dieOnFatal) {
+        $this->_dieOnFatal = $dieOnFatal;
     }
 
     protected function _log($level, $errorFlag, $fmt, $allArgs) {

--- a/lib/Client/NoOpSpan.php
+++ b/lib/Client/NoOpSpan.php
@@ -34,4 +34,5 @@ class NoOpSpan implements \LightStepBase\Span {
     public function warnf($fmt) {}
     public function errorf($fmt) {}
     public function fatalf($fmt) {}
+    public function setDieOnFatal($dieOnFatal) {}
 }

--- a/lib/api.php
+++ b/lib/api.php
@@ -249,10 +249,6 @@ interface Span {
      * Creates a printf-style error log statement that will be associated with
      * this particular operation instance.
      *
-     * If the runtime is enabled, the implementation *will* call die() after
-     * creating the log (if the runtime is disabled, the log record will
-     * not be created and the die() call will not be made).
-     *
      * @param string $fmt a format string as accepted by sprintf
      */
     public function errorf($fmt);
@@ -261,9 +257,21 @@ interface Span {
      * Creates a printf-style fatal log statement that will be associated with
      * this particular operation instance.
      *
+     * If the runtime is enabled, the implementation *will* call die() after
+     * creating the log. If the runtime is disabled, the log record will
+     * not be created and the die() call will not be made.
+     *
      * @param string $fmt a format string as accepted by sprintf
      */
     public function fatalf($fmt);
+
+    /**
+     * Provides a mechanism to prevent fatalf from calling die() after
+     * creating a log.
+     *
+     * @param bool $dieOnFatal
+     */
+    public function setDieOnFatal($dieOnFatal);
 
     // ---------------------------------------------------------------------- //
     // Deprecated

--- a/test/RuntimeDisableTest.php
+++ b/test/RuntimeDisableTest.php
@@ -11,6 +11,7 @@ class RuntimeDisableTest extends BaseLightStepTest {
         $span->addTraceJoinId("key_to_an", "unused_value");
         $span->warnf("Shouldn't do anything");
         $span->errorf("Shouldn't do anything");
+        $span->fatalf("Shouldn't do anything");
         $span->finish();
     }
 }

--- a/test/SpanTest.php
+++ b/test/SpanTest.php
@@ -51,6 +51,8 @@ class SpanTest extends BaseLightStepTest {
         $span->infof("Test %d %f %s", 1, 2.0, "three");
         $span->warnf("Test %d %f %s", 1, 2.0, "three");
         $span->errorf("Test %d %f %s", 1, 2.0, "three");
+        $span->setDieOnFatal(false);
+        $span->fatalf("Test %d %f %s", 1, 2.0, "three");
         $span->finish();
     }
 


### PR DESCRIPTION
Moved the comments to the right method and added another method to let users prevent `die()` from being called. This change does not change the default behaviour which remains as before.

Fixes #57 