### PR TITLE
Fix maxPayloadDepth property assignment in ClientSpan

### DIFF
--- a/lib/Client/ClientSpan.php
+++ b/lib/Client/ClientSpan.php
@@ -35,7 +35,7 @@ class ClientSpan implements \LightStepBase\Span {
         $this->_tracer = $tracer;
         $this->_traceGUID = $tracer->_generateUUIDString();
         $this->_guid = $tracer->_generateUUIDString();
-        $this->$maxPayloadDepth = $maxPayloadDepth;
+        $this->maxPayloadDepth = $maxPayloadDepth;
     }
 
     public function __destruct() {


### PR DESCRIPTION
## Description of the change
Fix `maxPayloadDepth` property assignment in ClientSpan.

Before, when you instantiate a new instance of `LightStepBase\Client\ClientSpan`, uses the value of `$maxPayloadDepth` as the property name on the instance. So for example, if `$maxPayloadDepth` was set to `10`, the instance would suddenly have a property called `10` with the value `10`.

With this change, it actually assigns the value to the `maxPayloadDepth` property

---
hey @smithclay / @tylerbenson, any chance you could review this? I realise this library is deprecated/abandoned but it would still be good to get this fixed (it also fixes a PHP 8.2 deprecation warning like: `Deprecated:  Creation of dynamic property LightStepBase\Client\ClientSpan::$10 is deprecated in lightstep/tracer/lib/Client/ClientSpan.php on line 38`. Thanks in advance!